### PR TITLE
With mapping

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="Hashids.net" Version="1.6.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.18.0" />
     <PackageReference Include="FastEndpoints" Version="5.4.1" />
 		<PackageReference Include="FastEndpoints.Swagger" Version="5.4.1" />

--- a/src/Api/Endpoints/Url/CreateShortUrlEndpoint.cs
+++ b/src/Api/Endpoints/Url/CreateShortUrlEndpoint.cs
@@ -15,7 +15,6 @@ public class CreateShortUrlSummary : Summary<CreateShortUrlEndpoint>
         Response(500, "Internal server error.");
     }
 }
-
 public class CreateShortUrlEndpoint : BaseEndpoint<CreateShortUrlRequest>
 {
     public CreateShortUrlEndpoint(ISender mediator, IMapper mapper)
@@ -31,7 +30,6 @@ public class CreateShortUrlEndpoint : BaseEndpoint<CreateShortUrlRequest>
         );
         Summary(new CreateShortUrlSummary());
     }
-
     public override async Task HandleAsync(CreateShortUrlRequest req, CancellationToken ct)
     {
         var result = await Mediator.Send(

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -13,6 +13,8 @@
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
         <PackageReference Include="Hashids.net" Version="1.6.1" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.2.22472.11" />
     </ItemGroup>
 

--- a/src/Application/Url/Commands/CreateShortUrlCommand.cs
+++ b/src/Application/Url/Commands/CreateShortUrlCommand.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Web;
 using FluentValidation;
 using HashidsNet;
 using MediatR;
@@ -25,15 +28,23 @@ public class CreateShortUrlCommandHandler : IRequestHandler<CreateShortUrlComman
     private readonly IApplicationDbContext _context;
     private readonly IHashids _hashids;
 
+    //private List<string> hashedUrls = new List<string>();
+
     public CreateShortUrlCommandHandler(IApplicationDbContext context, IHashids hashids)
     {
         _context = context;
         _hashids = hashids;
     }
-
     public async Task<string> Handle(CreateShortUrlCommand request, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
-        throw new NotImplementedException();
+        var shortUrl = "http://localhost:5246/u/" + encode(request.Url);
+        //hashedUrls.Add(shortUrl);
+        return shortUrl;
+    }
+    public string encode(string url) {
+        byte[] bytes = Encoding.UTF8.GetBytes(url);
+        var hex = Convert.ToHexString(bytes);
+        return _hashids.EncodeHex(hex);
     }
 }

--- a/src/Application/Url/Commands/RedirectToUrlCommand.cs
+++ b/src/Application/Url/Commands/RedirectToUrlCommand.cs
@@ -39,23 +39,7 @@ public class RedirectToUrlCommandHandler : IRequestHandler<RedirectToUrlCommand,
     public async Task<string> Handle(RedirectToUrlCommand request, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
-        var decoded = decode(request.Id);
-        return new RedirectResult(decoded).Url;
-    }
-    public static byte[] FromHex(string hex)
-    {
-        hex = hex.Replace("-", "");
-        byte[] raw = new byte[hex.Length / 2];
-        for (int i = 0; i < raw.Length; i++)
-        {
-            raw[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
-        }
-    return raw;
-}
-
-    public string decode(string id) {
-        var hex = _hashids.DecodeHex(id);
-        byte[] data = FromHex(hex);
-        return Encoding.UTF8.GetString(data);
+        var url = _context.Urls.FirstOrDefault(url => url.Id == request.Id);
+        return new RedirectResult(url.OriginalUrl).Url;
     }
 }

--- a/src/Application/Url/Commands/RedirectToUrlCommand.cs
+++ b/src/Application/Url/Commands/RedirectToUrlCommand.cs
@@ -1,7 +1,12 @@
+using System.Security.Cryptography;
+using System.Text;
 using FluentValidation;
 using HashidsNet;
 using MediatR;
 using UrlShortenerService.Application.Common.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using System.Web;
 
 namespace UrlShortenerService.Application.Url.Commands;
 
@@ -34,6 +39,23 @@ public class RedirectToUrlCommandHandler : IRequestHandler<RedirectToUrlCommand,
     public async Task<string> Handle(RedirectToUrlCommand request, CancellationToken cancellationToken)
     {
         await Task.CompletedTask;
-        throw new NotImplementedException();
+        var decoded = decode(request.Id);
+        return new RedirectResult(decoded).Url;
+    }
+    public static byte[] FromHex(string hex)
+    {
+        hex = hex.Replace("-", "");
+        byte[] raw = new byte[hex.Length / 2];
+        for (int i = 0; i < raw.Length; i++)
+        {
+            raw[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        }
+    return raw;
+}
+
+    public string decode(string id) {
+        var hex = _hashids.DecodeHex(id);
+        byte[] data = FromHex(hex);
+        return Encoding.UTF8.GetString(data);
     }
 }

--- a/src/Domain/Entities/Url.cs
+++ b/src/Domain/Entities/Url.cs
@@ -22,6 +22,10 @@ public class Url : BaseAuditableEntity
     /// The original url.
     /// </summary>
     public string OriginalUrl { get; set; } = default!;
+    /// <summary>
+    /// The short id.
+    /// </summary>
+    public string Id { get; set; } = default!;
 
     #endregion
 }


### PR DESCRIPTION
Right now the service works just by encoding & decoding the URL (deterministic hashes).

This change introduces the use of DB-context, to create a mapping from short_ID -> URL.

IDs no longer need to be decoded to the original URL, so they can be much shorter now.